### PR TITLE
[NEW] Travis config for deployment on tags ; User and password still need to be given

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,9 @@ script: py.test
 branches:
   only:
     - master
+deploy:
+  provider: pypi
+  username: 
+  password:
+  on:
+    tags: true


### PR DESCRIPTION
**Problem**
In order to do continuous deployment, we needed an easy way to publish our releases to PyPi

**Solution**
The `.travis.yml` file was updated, with a deployment condition. The username and passwords have not been given. To add them, see the documentation for [Travis deployment](https://docs.travis-ci.com/user/deployment) and [Travis encrypting mechanism](https://docs.travis-ci.com/user/encryption-keys/)
