### PR TITLE
Display of task without preview improved

### DIFF
--- a/gazupublisher/utils/date.py
+++ b/gazupublisher/utils/date.py
@@ -1,0 +1,39 @@
+"""
+The dates in the database are written with this format : "1900-01-01T00:00:00".
+This module contains functions to manage the display of these dates and other
+utility functions.
+"""
+
+import datetime
+
+
+def compare_date(d1, d2):
+    """
+    Return whether d1 is more recent than d2
+    """
+    date1 = extract_date(d1)
+    date2 = extract_date(d2)
+    return date1 > date2
+
+
+def extract_date(date):
+    """
+    Extract day and hour from database date format.
+    """
+    return datetime.datetime.strptime(date, '%Y-%m-%dT%H:%M:%S')
+
+
+def format_comment_date(comment_date):
+    """
+    Return a more pleasant format for comment date display.
+    """
+    date = extract_date(comment_date)
+    return date.strftime('%Y-%m-%d %H:%M:%S')
+
+
+def format_table_date(table_date):
+    """
+    Return a more pleasant format for date and hour display.
+    """
+    date = extract_date(table_date)
+    return date.strftime('%Y-%m-%d')

--- a/gazupublisher/utils/other.py
+++ b/gazupublisher/utils/other.py
@@ -1,6 +1,3 @@
-import re
-import datetime
-
 import Qt.QtGui as QtGui
 
 formats = {
@@ -16,48 +13,6 @@ def is_video(preview_file):
     """
     ext = preview_file["extension"]
     return ext in formats["video"]
-
-
-def compare_date(d1, d2):
-    """
-    Return whether d1 is more recent than d2
-    """
-    year1, month1, day1, hour1, minute1, second1 = extract_date(d1)
-    year2, month2, day2, hour2, minute2, second2 = extract_date(d2)
-    date1 = datetime.datetime(int(year1), int(month1), int(day1))
-    date2 = datetime.datetime(int(year2), int(month2), int(day2))
-    if date1 != date2:
-        return date1 > date2
-    daytime_second1 = 3600 * hour1 + 60 * minute1 + second1
-    daytime_second2 = 3600 * hour2 + 60 * minute2 + second2
-    return daytime_second1 > daytime_second2
-
-
-def extract_date(date):
-    """
-    Extract day and hour from database date format.
-    """
-    match = re.match(r"(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)", date)
-    return match.groups()
-
-
-def format_date(date):
-    """
-    Return a more pleasant format for date display.
-    """
-    year, month, day, _, _, _ = extract_date(date)
-    full_day = year + "-" + month + "-" + day
-    return full_day
-
-
-def format_date_and_hour(date):
-    """
-    Return a more pleasant format for date and hour display.
-    """
-    year, month, day, hour, minute, _ = extract_date(date)
-    full_day = year + "-" + month + "-" + day
-    time = hour + ":" + minute
-    return full_day + "  " + time
 
 
 def combine_colors(c1, c2, factor=0.5):

--- a/gazupublisher/views/CustomToolBar.py
+++ b/gazupublisher/views/CustomToolBar.py
@@ -35,7 +35,7 @@ class CustomToolBar(QtWidgets.QToolBar):
             "Reload the table",
             self,
         )
-        self.reload_action.triggered.connect(self.window.table.reload)
+        self.reload_action.triggered.connect(self.window.reload)
         self.addAction(self.reload_action)
 
         self.open_in_browser_action = QtWidgets.QAction(

--- a/gazupublisher/views/TasksTabItem.py
+++ b/gazupublisher/views/TasksTabItem.py
@@ -2,7 +2,8 @@ import Qt.QtWidgets as QtWidgets
 import Qt.QtGui as QtGui
 import Qt.QtCore as QtCore
 
-from gazupublisher.utils.other import combine_colors, format_date
+from gazupublisher.utils.other import combine_colors
+from gazupublisher.utils.date import format_table_date
 
 
 class TasksTabItem(QtWidgets.QTableWidgetItem):
@@ -37,7 +38,7 @@ class TasksTabItem(QtWidgets.QTableWidgetItem):
 
         else:
             if self.task_attribute == "task_due_date" and text:
-                text = format_date(text)
+                text = format_table_date(text)
             elif self.task_attribute == "entity_name":
                 text = self.task["entity_type_name"] + "/" + text
         self.setText(str(text))

--- a/gazupublisher/views/task_panel/CommentWidget.py
+++ b/gazupublisher/views/task_panel/CommentWidget.py
@@ -86,7 +86,7 @@ class CommentWidget(QtWidgets.QWidget):
 
             self.le.clear()
             self.reset_selector_btn()
-            self.panel.reload()
+            self.panel.parent.reload()
 
     def open_file_selector(self):
         """

--- a/gazupublisher/views/task_panel/ItemCommentTask.py
+++ b/gazupublisher/views/task_panel/ItemCommentTask.py
@@ -3,7 +3,9 @@ import os
 from Qt import QtCore, QtGui, QtWidgets, QtCompat
 
 from gazupublisher.utils.connection import get_host, get_file_data_from_url
-from gazupublisher.utils.other import format_date_and_hour, combine_colors
+from gazupublisher.utils.other import combine_colors
+from gazupublisher.utils.date import format_comment_date
+
 from gazupublisher.ui_data.color import main_color, text_color
 
 
@@ -59,7 +61,7 @@ class WidgetCommentTask(QtWidgets.QWidget):
         self.sender_name.setText(name)
 
     def display_creation_date(self):
-        creation_date = format_date_and_hour(self.comment["created_at"])
+        creation_date = format_comment_date(self.comment["created_at"])
         self.sender_name.setStyleSheet("font-weight: bold")
         self.date.setText(creation_date)
 

--- a/gazupublisher/views/task_panel/NoPreviewWidget.py
+++ b/gazupublisher/views/task_panel/NoPreviewWidget.py
@@ -1,0 +1,29 @@
+import Qt.QtWidgets as QtWidgets
+import Qt.QtGui as QtGui
+
+from gazupublisher.ui_data.color import text_color
+
+
+class NoPreviewWidget(QtWidgets.QWidget):
+    """
+    Widget to display when the task has no preview.
+    """
+    def __init__(self, *args, **kwargs):
+        QtWidgets.QWidget.__init__(self, *args, **kwargs)
+        self.no_preview_label = QtWidgets.QLabel("No preview yet")
+        pal = self.no_preview_label.palette()
+        pal.setColor(QtGui.QPalette.WindowText,
+                     QtGui.QColor(text_color).darker(140))
+        self.no_preview_label.setPalette(pal)
+        self.no_preview_label.setFont(
+            QtGui.QFont("Arial", pointSize=12, italic=True)
+        )
+        horizontal_label_layout = QtWidgets.QHBoxLayout(self)
+        horizontal_label_layout.setSpacing(6)
+        horizontal_label_layout.addWidget(self.no_preview_label)
+        
+    def clear(self):
+        """
+        Clear the children.
+        """
+        self.no_preview_label.deleteLater()

--- a/gazupublisher/views/task_panel/PreviewWidget.py
+++ b/gazupublisher/views/task_panel/PreviewWidget.py
@@ -54,7 +54,6 @@ class PreviewWidget(QtWidgets.QWidget):
         self.preview_vertical_layout.removeWidget(self.full_screen_button)
         self.preview_vertical_layout.removeWidget(self.toolbar_widget)
         self.clear_setup_media_widget()
-        self.deleteLater()
 
     def clear_setup_media_widget(self):
         pass

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -1,7 +1,8 @@
 from Qt import QtCore, QtGui, QtWidgets, QtCompat
 
 from gazupublisher.utils.data import get_all_previews_for_task
-from gazupublisher.utils.other import is_video, compare_date
+from gazupublisher.utils.other import is_video
+from gazupublisher.utils.date import compare_date
 from gazupublisher.views.task_panel.PreviewImageWidget import PreviewImageWidget
 from gazupublisher.views.task_panel.PreviewVideoWidget import PreviewVideoWidget
 from gazupublisher.views.task_panel.ListCommentTask import ListCommentTask

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -121,4 +121,5 @@ class TaskPanel(QtWidgets.QWidget):
         """
         self.list_comments.clear()
         self.preview_widget.clear()
+        self.preview_widget.deleteLater()
         self.preview_widget = None

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -5,6 +5,7 @@ from gazupublisher.utils.other import is_video
 from gazupublisher.utils.date import compare_date
 from gazupublisher.views.task_panel.PreviewImageWidget import PreviewImageWidget
 from gazupublisher.views.task_panel.PreviewVideoWidget import PreviewVideoWidget
+from gazupublisher.views.task_panel.NoPreviewWidget import NoPreviewWidget
 from gazupublisher.views.task_panel.ListCommentTask import ListCommentTask
 from gazupublisher.views.task_panel.CommentWidget import CommentWidget
 
@@ -89,13 +90,7 @@ class TaskPanel(QtWidgets.QWidget):
         Create the preview following the type of object to display.
         """
         if not self.preview_file:
-            self.preview_widget = QtWidgets.QLabel("No preview yet")
-            self.preview_widget.setFont(
-                QtGui.QFont("Arial", pointSize=10, italic=True)
-            )
-            self.preview_widget.setStyleSheet(
-                "QLabel { background-color: #D2CAD5 }"
-            )
+            self.preview_widget = NoPreviewWidget()
 
         else:
             if is_video(self.preview_file):


### PR DESCRIPTION
**Problem**
For a task without preview, the visual aspect needs to be changed.
Date management using regular expressions is odd.
Some bugs concerning reloading are present \: 
- When the task has not any preview, the associated widget is not removed when changing task. 

- The table is not updated when posting comments.

**Solution**
The display of a task without preview has been modified.
Date management is now done properly with the module datetime.
Bugs described above have been fixed.
