### PR TITLE
Reformat table duration, task status, entity names

### DIFF
--- a/gazupublisher/views/TasksTabItem.py
+++ b/gazupublisher/views/TasksTabItem.py
@@ -43,6 +43,8 @@ class TasksTabItem(QtWidgets.QTableWidgetItem):
                 text = self.task["entity_type_name"] + "/" + text
             elif self.task_attribute == "task_status_short_name":
                 text = text.upper()
+            elif self.task_attribute == "task_duration":
+                text = str(round(int(text)/(5*8*12), 1))
         self.setText(str(text))
 
     def paint_background(self):

--- a/gazupublisher/views/TasksTabItem.py
+++ b/gazupublisher/views/TasksTabItem.py
@@ -40,7 +40,15 @@ class TasksTabItem(QtWidgets.QTableWidgetItem):
             if self.task_attribute == "task_due_date" and text:
                 text = format_table_date(text)
             elif self.task_attribute == "entity_name":
-                text = self.task["entity_type_name"] + "/" + text
+                seq_name = self.task["sequence_name"]
+                if seq_name:
+                    ep_name = self.task["episode_name"]
+                    if ep_name:
+                        text = ep_name + " / " + seq_name + " / " + text
+                    else:
+                        text = seq_name + " / " + text
+                else:
+                    text = self.task["entity_type_name"] + "/" + text
             elif self.task_attribute == "task_status_short_name":
                 text = text.upper()
             elif self.task_attribute == "task_duration":

--- a/gazupublisher/views/TasksTabItem.py
+++ b/gazupublisher/views/TasksTabItem.py
@@ -41,6 +41,8 @@ class TasksTabItem(QtWidgets.QTableWidgetItem):
                 text = format_table_date(text)
             elif self.task_attribute == "entity_name":
                 text = self.task["entity_type_name"] + "/" + text
+            elif self.task_attribute == "task_status_short_name":
+                text = text.upper()
         self.setText(str(text))
 
     def paint_background(self):


### PR DESCRIPTION
**Problem**
The task status is in lower case.
The task duration unit is a time of 5 minutes.
The entity names don't include episode and sequence names.

**Solution**
The task status is now in upper case.
The task duration is now in days.
The entity names now include episode and sequence names.