### PR TITLE
Change project root

### DIFF
--- a/blender_addon/launch_kitsu.py
+++ b/blender_addon/launch_kitsu.py
@@ -3,29 +3,18 @@
 Test for running a Qt app in Blender.
 This code reuses this snippet : https://gitlab.com/snippets/1881226
 Using a timed modal operator to keep the Qt GUI alive and communicate via
-`queue.Queue`. So far this seems to work fine on Linux and Windows (macOS
-is untested at the moment).
+`queue.Queue`.
 
 isort:skip_file
 """
-
-pyqt5_path = "<your_pyqt5_path_here>"
-
-import functools
 import queue
-import sys
+from Qt import QtCore, QtWidgets
+from gazupublisher.gazupublisher.__main__ import create_display_entities
 import bpy
-
-from pprint import pformat
-
-sys.path.append(pyqt5_path)
-from PyQt5 import QtCore, QtWidgets
-from gazu_publisher.gazupublisher.__main__ import create_display_entities
-
 
 bl_info = {
     "name": "Qt Launcher",
-    "author": "CGWire",
+    "author": "LedruRollin",
     "location": "Main Toolbar > Window > Launch Qt",
     "description": "Launch Qt",
     "category": "Launch Qt",
@@ -48,17 +37,15 @@ def _process_qt_queue(self):
 
     while not self._qt_queue.empty():
         function = self._qt_queue.get()
-        custom_print(
-            f"Running `{function.func.__name__}` from the Qt queue..."
-        )
+        custom_print(f"Running `{function.func.__name__}` from the Qt queue...")
         function()
 
 
 def custom_print(data):
-    # """
-    # Override print to display to console
-    # :param data: Any printable data
-    # """
+    """
+    Override print to display to console
+    :param data: Any printable data
+    """
     for window in bpy.context.window_manager.windows:
         screen = window.screen
         for area in screen.areas:
@@ -131,14 +118,24 @@ class BlenderQtAppTimedQueue(bpy.types.Operator):
         """Remove event timer when stopping the operator."""
         wm = context.window_manager
         wm.event_timer_remove(self._timer)
+        self._window.deleteLater()
+        self._app.quit()
+        self._window = None
+        self._app = None
 
 
 def register():
+    """
+    Register the class and add the drawer to the menu
+    """
     bpy.utils.register_class(BlenderQtAppTimedQueue)
     bpy.types.INFO_MT_window.append(menu_draw)
 
 
 def unregister():
+    """
+    Unregister the class and delete the drawer from the menu
+    """
     bpy.utils.unregister_class(BlenderQtAppTimedQueue)
     bpy.types.INFO_MT_window.remove(menu_draw)
 

--- a/gazupublisher/__main__.py
+++ b/gazupublisher/__main__.py
@@ -4,9 +4,9 @@ import Qt.QtWidgets as QtWidgets
 import Qt.QtCore as QtCore
 import Qt.QtGui as QtGui
 
-from gazupublisher.views.MainWindow import MainWindow
-from gazupublisher.ui_data.color import main_color, text_color
-from qtazu.widgets.login import Login
+from gazupublisher.gazupublisher.views.MainWindow import MainWindow
+from gazupublisher.gazupublisher.ui_data.color import main_color, text_color
+from qtazu.qtazu.widgets.login import Login
 
 # Hack to allow to close the application with Ctrl+C
 import signal

--- a/gazupublisher/utils/file.py
+++ b/gazupublisher/utils/file.py
@@ -1,8 +1,27 @@
 import os
+from Qt import QtGui, QtCompat
 
 
-def from_list_paths_to_list_files(list_paths):
+def load_ui_file(ui_file, base_instance):
+    current_abs_path = os.path.realpath(__file__)
+    root_path = os.path.dirname(
+        os.path.dirname(os.path.dirname(current_abs_path))
+    )
+    ui_path = os.path.join(root_path, "resources", "views", ui_file)
+    QtCompat.loadUi(ui_path, base_instance)
+
+
+def get_icon_file(icon_file):
+    current_abs_path = os.path.realpath(__file__)
+    root_path = os.path.dirname(
+        os.path.dirname(os.path.dirname(current_abs_path))
+    )
+    icon_path = os.path.join(root_path, "resources", "icons", icon_file)
+    return QtGui.QIcon(icon_path)
+
+
+def extract_filenames_list(list_paths):
     """
-    Return a list of files from a list of path.
+    Return a list of filenames from a list of paths.
     """
     return [os.path.basename(path) for path in list_paths]

--- a/gazupublisher/views/CustomToolBar.py
+++ b/gazupublisher/views/CustomToolBar.py
@@ -31,7 +31,7 @@ class CustomToolBar(QtWidgets.QToolBar):
         self.combobox.currentIndexChanged.connect(self.click_combobox)
 
         self.reload_action = QtWidgets.QAction(
-            QtGui.QIcon("../resources/icons/refresh.png"),
+            get_icon_file("refresh.png"),
             "Reload the table",
             self,
         )
@@ -39,7 +39,7 @@ class CustomToolBar(QtWidgets.QToolBar):
         self.addAction(self.reload_action)
 
         self.open_in_browser_action = QtWidgets.QAction(
-            QtGui.QIcon("../resources/icons/open-in-browser.png"),
+            get_icon_file("open-in-browser.png"),
             "Open in browser",
             self,
         )

--- a/gazupublisher/views/CustomToolBar.py
+++ b/gazupublisher/views/CustomToolBar.py
@@ -1,8 +1,8 @@
 from Qt import QtCore, QtGui, QtWidgets
 
-from gazupublisher.utils.connection import open_browser
-from gazupublisher.ui_data.color import main_color, text_color
-
+from gazupublisher.gazupublisher.utils.connection import open_browser
+from gazupublisher.gazupublisher.ui_data.color import main_color, text_color
+from gazupublisher.gazupublisher.utils.file import get_icon_file
 
 class CustomToolBar(QtWidgets.QToolBar):
     def __init__(self, window):

--- a/gazupublisher/views/MainWindow.py
+++ b/gazupublisher/views/MainWindow.py
@@ -2,10 +2,9 @@ import os
 
 from Qt import QtCore, QtWidgets
 
-from .MainWindow_ui import Ui_MainWindow
-from gazupublisher.ui_data.ui_values import height_app
+from gazupublisher.gazupublisher.views.MainWindow_ui import Ui_MainWindow
 
-from .. import exceptions
+from gazupublisher.gazupublisher import exceptions
 
 
 class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):

--- a/gazupublisher/views/MainWindow_ui.py
+++ b/gazupublisher/views/MainWindow_ui.py
@@ -2,12 +2,11 @@
 
 from Qt import QtCore, QtWidgets
 
-from ui_data.table_headers import tab_columns
+from gazupublisher.gazupublisher.ui_data.table_headers import tab_columns
 
-from gazupublisher.views.TasksTab import TasksTab
-from gazupublisher.views.CustomToolBar import CustomToolBar
-from gazupublisher.views.task_panel.TaskPanel import TaskPanel
-from gazupublisher.ui_data.color import main_color
+from gazupublisher.gazupublisher.views.TasksTab import TasksTab
+from gazupublisher.gazupublisher.views.CustomToolBar import CustomToolBar
+from gazupublisher.gazupublisher.views.task_panel.TaskPanel import TaskPanel
 
 
 class Ui_MainWindow(object):

--- a/gazupublisher/views/TasksTab.py
+++ b/gazupublisher/views/TasksTab.py
@@ -2,15 +2,18 @@ import Qt.QtWidgets as QtWidgets
 import Qt.QtCore as QtCore
 import Qt.QtGui as QtGui
 
-import gazupublisher.utils.data as utils_data
-from gazupublisher.utils.other import combine_colors
-from gazupublisher.views.TasksTabItem import TasksTabItem
-from gazupublisher.ui_data.color import (
+import gazupublisher.gazupublisher.utils.data as utils_data
+from gazupublisher.gazupublisher.utils.other import combine_colors
+from gazupublisher.gazupublisher.views.TasksTabItem import TasksTabItem
+from gazupublisher.gazupublisher.ui_data.color import (
     main_color,
     table_alternate_color,
     text_color,
 )
-from gazupublisher.ui_data.ui_values import height_table, row_height
+from gazupublisher.gazupublisher.ui_data.ui_values import (
+    height_table,
+    row_height,
+)
 
 
 class StyleDelegateForQTableWidget(QtWidgets.QStyledItemDelegate):

--- a/gazupublisher/views/TasksTabItem.py
+++ b/gazupublisher/views/TasksTabItem.py
@@ -2,8 +2,11 @@ import Qt.QtWidgets as QtWidgets
 import Qt.QtGui as QtGui
 import Qt.QtCore as QtCore
 
-from gazupublisher.utils.other import combine_colors, from_min_to_day
-from gazupublisher.utils.date import format_table_date
+from gazupublisher.gazupublisher.utils.other import (
+    combine_colors,
+    from_min_to_day,
+)
+from gazupublisher.gazupublisher.utils.date import format_table_date
 
 
 class TasksTabItem(QtWidgets.QTableWidgetItem):

--- a/gazupublisher/views/task_panel/CommentWidget.py
+++ b/gazupublisher/views/task_panel/CommentWidget.py
@@ -4,7 +4,7 @@ import Qt.QtCore as QtCore
 import Qt.QtWidgets as QtWidgets
 import Qt.QtGui as QtGui
 
-import gazupublisher.utils.data as utils_data
+import gazupublisher.gazupublisher.utils.data as utils_data
 
 
 class CommentWidget(QtWidgets.QWidget):

--- a/gazupublisher/views/task_panel/ItemCommentTask.py
+++ b/gazupublisher/views/task_panel/ItemCommentTask.py
@@ -1,12 +1,12 @@
 import os
 
-from Qt import QtCore, QtGui, QtWidgets, QtCompat
+from Qt import QtCore, QtGui, QtWidgets
 
-from gazupublisher.utils.connection import get_host, get_file_data_from_url
-from gazupublisher.utils.other import combine_colors
-from gazupublisher.utils.date import format_comment_date
-
-from gazupublisher.ui_data.color import main_color, text_color
+from gazupublisher.gazupublisher.utils.connection import get_file_data_from_url
+from gazupublisher.gazupublisher.utils.other import combine_colors
+from gazupublisher.gazupublisher.utils.date import format_comment_date
+from gazupublisher.gazupublisher.utils.file import load_ui_file
+from gazupublisher.gazupublisher.ui_data.color import main_color
 
 
 class WidgetCommentTask(QtWidgets.QWidget):

--- a/gazupublisher/views/task_panel/ItemCommentTask.py
+++ b/gazupublisher/views/task_panel/ItemCommentTask.py
@@ -21,7 +21,7 @@ class WidgetCommentTask(QtWidgets.QWidget):
         self.setup_ui()
 
     def setup_ui(self):
-        QtCompat.loadUi("../resources/views/CommentWidget.ui", self)
+        load_ui_file("CommentWidget.ui", self)
         self.setLayout(self.gridLayout)
 
         self.comment_textedit = self.findChild(

--- a/gazupublisher/views/task_panel/ListCommentTask.py
+++ b/gazupublisher/views/task_panel/ListCommentTask.py
@@ -1,8 +1,13 @@
 from Qt import QtCore, QtGui, QtWidgets
 
-from gazupublisher.utils.data import get_all_comments_for_task
-from gazupublisher.views.task_panel.ItemCommentTask import WidgetCommentTask
-from gazupublisher.views.task_panel.NoPreviewWidget import NoPreviewWidget
+from gazupublisher.gazupublisher.utils.data import get_all_comments_for_task
+from gazupublisher.gazupublisher.views.task_panel.ItemCommentTask import (
+    WidgetCommentTask,
+)
+from gazupublisher.gazupublisher.views.task_panel.NoPreviewWidget import (
+    NoPreviewWidget,
+)
+
 
 class ListCommentTask(QtWidgets.QListWidget):
     """
@@ -34,6 +39,7 @@ class ListCommentTask(QtWidgets.QListWidget):
         """
         Fill the widget with the comment items.
         """
+
         def add_widget_to_list(list_widget, widget):
             """
             Create an item so that the list can hold the widget

--- a/gazupublisher/views/task_panel/NoPreviewWidget.py
+++ b/gazupublisher/views/task_panel/NoPreviewWidget.py
@@ -2,7 +2,7 @@ import Qt.QtWidgets as QtWidgets
 import Qt.QtGui as QtGui
 import Qt.QtCore as QtCore
 
-from gazupublisher.ui_data.color import text_color
+from gazupublisher.gazupublisher.ui_data.color import text_color
 
 
 class NoPreviewWidget(QtWidgets.QWidget):

--- a/gazupublisher/views/task_panel/PreviewImageWidget.py
+++ b/gazupublisher/views/task_panel/PreviewImageWidget.py
@@ -2,8 +2,10 @@ import os
 
 from Qt import QtWidgets, QtGui, QtCore
 
-from gazupublisher.utils.connection import get_file_data_from_url
-from gazupublisher.views.task_panel.PreviewWidget import PreviewWidget
+from gazupublisher.gazupublisher.utils.connection import get_file_data_from_url
+from gazupublisher.gazupublisher.views.task_panel.PreviewWidget import (
+    PreviewWidget,
+)
 
 
 class CustomImageLabel(QtWidgets.QLabel):
@@ -94,7 +96,7 @@ class PreviewImageWidget(PreviewWidget):
         Return the height of the widget.
         """
         return (
-            self.image_label.height() +
-            2 * self.preview_vertical_layout.spacing() +
-            self.toolbar_widget.height()
+            self.image_label.height()
+            + 2 * self.preview_vertical_layout.spacing()
+            + self.toolbar_widget.height()
         )

--- a/gazupublisher/views/task_panel/PreviewVideoWidget.py
+++ b/gazupublisher/views/task_panel/PreviewVideoWidget.py
@@ -3,8 +3,10 @@ import os
 from Qt import QtCore, QtGui, QtWidgets
 from PyQt5 import QtMultimediaWidgets, QtMultimedia
 
-from gazupublisher.utils.connection import get_file_data_from_url, get_host
-from gazupublisher.views.task_panel.PreviewWidget import PreviewWidget
+from gazupublisher.gazupublisher.utils.connection import get_file_data_from_url
+from gazupublisher.gazupublisher.views.task_panel.PreviewWidget import (
+    PreviewWidget,
+)
 
 
 class SliderNoScroll(QtWidgets.QSlider):

--- a/gazupublisher/views/task_panel/PreviewWidget.py
+++ b/gazupublisher/views/task_panel/PreviewWidget.py
@@ -1,5 +1,6 @@
-from Qt import QtWidgets, QtCore, QtCompat
+from Qt import QtWidgets, QtCore
 
+from gazupublisher.gazupublisher.utils.file import load_ui_file
 
 class PreviewWidget(QtWidgets.QWidget):
     def __init__(self, parent, preview_file):
@@ -11,7 +12,7 @@ class PreviewWidget(QtWidgets.QWidget):
         self.manage_size()
 
     def setup_ui(self):
-        QtCompat.loadUi("../resources/views/PreviewWidget.ui", self)
+        load_ui_file("PreviewWidget.ui", self)
         self.preview_vertical_layout = self.findChild(
             QtWidgets.QVBoxLayout, "preview_vertical_layout"
         )

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -1,13 +1,24 @@
 from Qt import QtCore, QtGui, QtWidgets, QtCompat
 
-from gazupublisher.utils.data import get_all_previews_for_task
-from gazupublisher.utils.format import is_video
-from gazupublisher.utils.date import compare_date
-from gazupublisher.views.task_panel.PreviewImageWidget import PreviewImageWidget
-from gazupublisher.views.task_panel.PreviewVideoWidget import PreviewVideoWidget
-from gazupublisher.views.task_panel.NoPreviewWidget import NoPreviewWidget
-from gazupublisher.views.task_panel.ListCommentTask import ListCommentTask
-from gazupublisher.views.task_panel.CommentWidget import CommentWidget
+from gazupublisher.gazupublisher.utils.data import get_all_previews_for_task
+from gazupublisher.gazupublisher.utils.other import is_video
+from gazupublisher.gazupublisher.utils.date import compare_date
+from gazupublisher.gazupublisher.utils.file import load_ui_file
+from gazupublisher.gazupublisher.views.task_panel.PreviewImageWidget import (
+    PreviewImageWidget,
+)
+from gazupublisher.gazupublisher.views.task_panel.PreviewVideoWidget import (
+    PreviewVideoWidget,
+)
+from gazupublisher.gazupublisher.views.task_panel.NoPreviewWidget import (
+    NoPreviewWidget,
+)
+from gazupublisher.gazupublisher.views.task_panel.ListCommentTask import (
+    ListCommentTask,
+)
+from gazupublisher.gazupublisher.views.task_panel.CommentWidget import (
+    CommentWidget,
+)
 
 
 class TaskPanel(QtWidgets.QWidget):

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -1,7 +1,7 @@
 from Qt import QtCore, QtGui, QtWidgets, QtCompat
 
 from gazupublisher.gazupublisher.utils.data import get_all_previews_for_task
-from gazupublisher.gazupublisher.utils.other import is_video
+from gazupublisher.gazupublisher.utils.format import is_video
 from gazupublisher.gazupublisher.utils.date import compare_date
 from gazupublisher.gazupublisher.utils.file import load_ui_file
 from gazupublisher.gazupublisher.views.task_panel.PreviewImageWidget import (

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -30,7 +30,7 @@ class TaskPanel(QtWidgets.QWidget):
         """
         Retrieve widgets from ui file.
         """
-        QtCompat.loadUi("../resources/views/TaskPanel.ui", self)
+        load_ui_file("TaskPanel.ui", self)
         self.scroll_area = self.findChild(QtWidgets.QScrollArea)
         self.scroll_widget = self.findChild(
             QtWidgets.QWidget, "scrollAreaWidgetContents"


### PR DESCRIPTION
**Problem**
When placed in the library management of Blender, the project fails to compile for a number of reasons. One of them is that the code inside the main directory (gazupublisher/gazupublisher) considers itself as the root, when it should points towards the main root of the project (gazupublisher/)

**Solution**
The whole project has been updated so that the imports are done correctly relative to the root. The loading of resources (.ui, images) has also been reworked on.
Minor name refactoring.
The Blender add-on has been updated (**WIP**)