### PR TITLE
Ensure Maya's Python2 compatibility

### DIFF
--- a/gazupublisher/resources/views/TaskPanel.ui
+++ b/gazupublisher/resources/views/TaskPanel.ui
@@ -316,6 +316,12 @@
                 </property>
                 <item>
                  <widget class="QPushButton" name="comment_btn">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="font">
                    <font>
                     <pointsize>12</pointsize>

--- a/gazupublisher/ui_data/table_headers.py
+++ b/gazupublisher/ui_data/table_headers.py
@@ -3,13 +3,28 @@ Module with the header names of the table.
 The keys are the task attributes we want to display, the values are the names
 the columns will have in the table.
 """
+from gazupublisher.utils.other import python_version
 
-tab_columns = {
-    "project_name": "Prod",
-    "task_type_name": "Type",
-    "entity_name": "Entity",
-    "task_estimation": "Est.",
-    "task_duration": "Dur.",
-    "task_due_date": "Due date",
-    "task_status_short_name": "Task status"
-}
+if python_version() >= (3, 6, 0):
+    tab_columns = {
+        "project_name": "Prod",
+        "task_type_name": "Type",
+        "entity_name": "Entity",
+        "task_estimation": "Est.",
+        "task_duration": "Dur.",
+        "task_due_date": "Due date",
+        "task_status_short_name": "Task status",
+    }
+else:
+    from collections import OrderedDict
+    tab_columns = OrderedDict(
+        [
+            ("project_name", "Prod"),
+            ("task_type_name", "Type"),
+            ("entity_name", "Entity"),
+            ("task_estimation", "Est."),
+            ("task_duration", "Dur."),
+            ("task_due_date", "Due date"),
+            ("task_status_short_name", "Task status"),
+        ]
+    )

--- a/gazupublisher/utils/other.py
+++ b/gazupublisher/utils/other.py
@@ -1,5 +1,8 @@
 import Qt.QtGui as QtGui
+import sys
 
+def python_version():
+    return sys.version_info
 
 def combine_colors(c1, c2, factor=0.5):
     """

--- a/gazupublisher/views/task_panel/CommentButton.py
+++ b/gazupublisher/views/task_panel/CommentButton.py
@@ -1,7 +1,0 @@
-import Qt.QtWidgets as QtWidgets
-
-
-class CommentButton(QtWidgets.QPushButton):
-    def __init__(self, comment_window, *args, **kwargs):
-        QtWidgets.QCheckBox.__init__(self, *args, **kwargs)
-        self.comment_window = comment_window

--- a/gazupublisher/views/task_panel/CommentWidget.py
+++ b/gazupublisher/views/task_panel/CommentWidget.py
@@ -115,7 +115,7 @@ class CommentWidget(QtWidgets.QWidget):
         file_to_post = os.path.basename(self.post_path)
         self.file_selector_btn.setToolTip(file_to_post)
 
-        font_metrics = QtGui.QFontMetrics(self.font())
+        font_metrics = QtGui.QFontMetrics(self.file_selector_btn.font())
         elided_text = font_metrics.elidedText(
             file_to_post,
             QtCore.Qt.ElideRight,

--- a/gazupublisher/views/task_panel/ItemCommentTask.py
+++ b/gazupublisher/views/task_panel/ItemCommentTask.py
@@ -18,6 +18,7 @@ class WidgetCommentTask(QtWidgets.QWidget):
         super(WidgetCommentTask, self).__init__()
         self.comment = comment
         self.color = self.comment["task_status"]["color"]
+        self.setStyleSheet("::section{background-color: %s;}" % main_color)
         self.setup_ui()
 
     def setup_ui(self):

--- a/gazupublisher/views/task_panel/ListCommentTask.py
+++ b/gazupublisher/views/task_panel/ListCommentTask.py
@@ -47,7 +47,7 @@ class ListCommentTask(QtWidgets.QListWidget):
             item = QtWidgets.QListWidgetItem()
             item.setFlags(item.flags() & QtCore.Qt.ItemIsSelectable)
             item.setSizeHint(QtCore.QSize(widget.width(), widget.height()))
-            widget.setFixedWidth(list_widget.parent.desired_geometry.width())
+            item.setForeground(QtGui.QColor("#90d692"))
             list_widget.height += widget.height()
             list_widget.addItem(item)
             list_widget.setItemWidget(item, widget)
@@ -57,7 +57,6 @@ class ListCommentTask(QtWidgets.QListWidget):
         if not list_comments:
             widget = NoPreviewWidget(self, "No comment yet")
             item = add_widget_to_list(self, widget)
-            # item.setForeground(widget.palette().color())
         for comment in list_comments:
             widget = WidgetCommentTask(comment)
             add_widget_to_list(self, widget)

--- a/gazupublisher/views/task_panel/NoPreviewWidget.py
+++ b/gazupublisher/views/task_panel/NoPreviewWidget.py
@@ -26,7 +26,7 @@ class NoPreviewWidget(QtWidgets.QWidget):
             self.setup_link()
 
         horizontal_label_layout = QtWidgets.QHBoxLayout()
-        horizontal_label_layout.setSpacing(0)
+        horizontal_label_layout.setContentsMargins(6, 6, 6, 6)
         horizontal_label_layout.addWidget(self.no_preview_label)
         self.setLayout(horizontal_label_layout)
 
@@ -35,11 +35,7 @@ class NoPreviewWidget(QtWidgets.QWidget):
         )
 
     def setup_color(self):
-        pal = self.no_preview_label.palette()
-        pal.setColor(
-            QtGui.QPalette.WindowText, QtGui.QColor(text_color).darker(140)
-        )
-        self.no_preview_label.setPalette(pal)
+        self.setStyleSheet('QLabel {color: %s}'%(QtGui.QColor(text_color).darker(140).name()))
         self.no_preview_label.setFont(
             QtGui.QFont("Arial", pointSize=12, italic=True)
         )
@@ -58,7 +54,7 @@ class NoPreviewWidget(QtWidgets.QWidget):
         self.no_preview_label.deleteLater()
 
     def sizeHint(self):
-        return QtCore.QSize(self.width(), 10)
+        return QtCore.QSize(self.width(), 40)
 
     def get_height(self):
         return self.height()

--- a/gazupublisher/views/task_panel/PreviewImageWidget.py
+++ b/gazupublisher/views/task_panel/PreviewImageWidget.py
@@ -24,7 +24,7 @@ class CustomImageLabel(QtWidgets.QLabel):
         self.setStyleSheet("QLabel { background-color: black }")
 
     def sizeHint(self):
-        ratio = 16 / 9
+        ratio = 16.0 / 9
         return QtCore.QSize(
             self.parent.desired_geometry.width(),
             self.parent.desired_geometry.width() / ratio,
@@ -54,7 +54,6 @@ class PreviewImageWidget(PreviewWidget):
         )
         self.add_buttons()
         self.image_label = CustomImageLabel(self.parent)
-        self.image_label.setFixedSize(self.image_label.size())
         self.fill_preview()
         self.preview_vertical_layout.insertWidget(
             0, self.image_label, QtCore.Qt.AlignCenter

--- a/gazupublisher/views/task_panel/PreviewVideoWidget.py
+++ b/gazupublisher/views/task_panel/PreviewVideoWidget.py
@@ -37,7 +37,7 @@ class CustomVideoWidget(QtMultimediaWidgets.QVideoWidget):
         self.setStyleSheet("QLabel { background-color: black }")
 
     def sizeHint(self):
-        ratio = 16 / 9
+        ratio = 16.0 / 9
         return QtCore.QSize(
             self.parent.desired_geometry.width(),
             self.parent.desired_geometry.width() / ratio,


### PR DESCRIPTION
**Problem**
Some bugs are still present in Maya, but not in Standalone (the core issue is that Maya is running in Python2 while a local Python3 was installed). This PR aims to solve most of them.

**Solution**
The size of the pictures in Maya was fixed.
Column order in Maya was fixed.
The bug of the elided text which expands neighbour widgets has been fixed.
The "No comment yet" widget is now properly displayed.
Item has now a set background color.