### PR TITLE
Fixed UI bugs at reload from background thread

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,15 @@ The application can be launched in standalone mode.
 To do so, go to the code (installed into your virtualenv, use 'pip show gazupublisher' to see the path), and simply launch the main file in the gazupublisher folder.
 Since it's not installed by default, Maya users need to install PySide2/PyQt5 in their virtual environment to make things work.
 
+Troubleshooting
+---------------
+
+If you're on Ubuntu/Debian and you encounter any bug on Maya regarding a failed ssl import, this may be caused by Maya itself.
+If then you observe a problem when launching this command (missing libssl and libcrypto librairies) :
+    ldd /usr/autodesk/maya2019/lib/python2.7/lib-dynload/_ssl.so
+Then please check the folder /usr/autodesk/maya2019/support/python/2.7.11 and follow the instructions given by Maya.
+If that last path leads to nowhere, you can try to find it with "locate ubuntu_ssl.so"
+
 About authors
 -------------
 

--- a/gazupublisher/resources/views/MainWindow.ui
+++ b/gazupublisher/resources/views/MainWindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>599</width>
+    <width>476</width>
     <height>608</height>
    </rect>
   </property>

--- a/gazupublisher/resources/views/TaskPanel.ui
+++ b/gazupublisher/resources/views/TaskPanel.ui
@@ -193,10 +193,16 @@
                <item>
                 <widget class="QLabel" name="header_task_entity_name">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>280</width>
+                   <height>0</height>
+                  </size>
                  </property>
                  <property name="font">
                   <font>
@@ -207,6 +213,9 @@
                  </property>
                  <property name="text">
                   <string>TextLabel</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>

--- a/gazupublisher/ui_data/ui_values.py
+++ b/gazupublisher/ui_data/ui_values.py
@@ -3,5 +3,6 @@ Module with the main constants for the global layout of the interface.
 """
 
 height_table = 600
+max_width_table=900
 height_app = 700
 row_height = 50

--- a/gazupublisher/views/MainWindow.py
+++ b/gazupublisher/views/MainWindow.py
@@ -104,6 +104,7 @@ class Worker(QtCore.QRunnable):
         self.args = args
         self.kwargs = kwargs
 
+    @QtCore.Slot()
     def run(self):
         """
         Initialise the runner function with passed args, kwargs.

--- a/gazupublisher/views/MainWindow.py
+++ b/gazupublisher/views/MainWindow.py
@@ -22,8 +22,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self.setup_translation("en_US")
         self.setupUi(self)
         self.set_up_main_gui_listeners()
-        self.launch_thread()
-
+        try:
+            self.toolbar.removeAction(self.toolbar.reload_action)
+            self.launch_thread()
+        except:
+            self.toolbar.addAction(self.toolbar.reload_action)
     def manage_size(self):
         """
         Manage size policy. Window can't be larger than full screen.

--- a/gazupublisher/views/MainWindow_ui.py
+++ b/gazupublisher/views/MainWindow_ui.py
@@ -23,7 +23,6 @@ class Ui_MainWindow(object):
         """
 
         self.table = TasksTab(self, tab_columns)
-
         self.toolbar = CustomToolBar(self)
         self.toolbar.setSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
@@ -53,3 +52,4 @@ class Ui_MainWindow(object):
         if hasattr(self, "task_panel"):
             self.task_panel.reload()
         self.table.reload()
+        self.table.resize_to_content()

--- a/gazupublisher/views/TasksTab.py
+++ b/gazupublisher/views/TasksTab.py
@@ -13,6 +13,7 @@ from gazupublisher.ui_data.color import (
 from gazupublisher.ui_data.ui_values import (
     height_table,
     row_height,
+    max_width_table,
 )
 
 
@@ -88,9 +89,10 @@ class TasksTab(QtWidgets.QTableWidget):
         self.clicked.connect(self.on_click)
 
     def manage_size(self):
-        self.setFixedWidth(
-            self.horizontalHeader().length() + self.verticalHeader().width() + 2
-        )
+        data_width = self.horizontalHeader().length() + self.verticalHeader().width() + 2
+        if data_width > max_width_table:
+            self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        self.setFixedWidth(min(max_width_table, data_width))
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed
         )
@@ -187,6 +189,7 @@ class TasksTab(QtWidgets.QTableWidget):
         Resize the table to its contents.
         """
         self.resizeColumnsToContents()
+        self.manage_size()
 
     def activate_sort(self):
         """

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -141,7 +141,13 @@ class TaskPanel(QtWidgets.QWidget):
             full_entity_name = "{}/{}".format(
                 self.task["entity_type_name"], self.task["entity_name"]
             )
-        self.header_task_entity_name.setText(full_entity_name)
+        font_metrics = QtGui.QFontMetrics(self.header_task_entity_name.font())
+        elided_text = font_metrics.elidedText(
+            full_entity_name,
+            QtCore.Qt.ElideRight,
+            self.header_task_entity_name.width(),
+        )
+        self.header_task_entity_name.setText(elided_text)
 
     def update_header_button(self):
         signal = self.header_task_open_webbrowser.clicked


### PR DESCRIPTION
**Problem**
The user needs to have real time updates without UI bugs
The user needs to use the application normally and do the updates by himself if the background thread can't perform the work for some reason

**Solution**
If the thread can't do its job, the user can manually do it with the icon "reload the table".
The table now resizes itself after table udates
The UI bugs regarding long task names have been solved 
A troubleshooting section was added in the readme. For now, only a section for Maya users on Ubuntu/Debian has been provided.
