### PR TITLE
Add animated preview support for Blender

### DIFF
--- a/gazupublisher/__main__.py
+++ b/gazupublisher/__main__.py
@@ -8,6 +8,12 @@ import Qt.QtGui as QtGui
 from gazupublisher.views.MainWindow import MainWindow
 from gazupublisher.ui_data.color import main_color, text_color
 from gazupublisher.utils.error_window import ResizableMessageBox
+from gazupublisher.working_context import (
+    set_working_context,
+    get_working_context,
+    is_maya_context,
+    is_blender_context,
+)
 from qtazu.widgets.login import Login
 
 
@@ -26,8 +32,7 @@ def excepthook(exc_type, exc_value, exc_traceback):
         traceback.format_exception(exc_type, exc_value, exc_traceback)
     )
     message = "%s%s" % (header, traceback_print)
-    from gazupublisher.working_context import working_context
-    if working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import blender_print
         blender_print(message)
     else:
@@ -99,8 +104,16 @@ def setup_dark_mode(app):
     palette.setColor(QtGui.QPalette.Link, QtGui.QColor(42, 130, 218))
     palette.setColor(QtGui.QPalette.Highlight, QtGui.QColor(42, 130, 218))
     palette.setColor(QtGui.QPalette.HighlightedText, QtCore.Qt.black)
-    palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.WindowText, QtGui.QColor(text_color).darker(170))
-    palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.ButtonText, QtGui.QColor(text_color).darker(170))
+    palette.setColor(
+        QtGui.QPalette.Disabled,
+        QtGui.QPalette.WindowText,
+        QtGui.QColor(text_color).darker(170),
+    )
+    palette.setColor(
+        QtGui.QPalette.Disabled,
+        QtGui.QPalette.ButtonText,
+        QtGui.QColor(text_color).darker(170),
+    )
     app.setPalette(palette)
 
 
@@ -109,9 +122,7 @@ def setup_style(app):
     Setup style. 'Fusion' is the wanted default style for this app.
     Maya already defines its own style.
     """
-    import gazupublisher.working_context as w
-    if "Fusion" in QtWidgets.QStyleFactory.keys()\
-            and w.working_context != "MAYA":
+    if "Fusion" in QtWidgets.QStyleFactory.keys() and not is_maya_context():
         app.setStyle("Fusion")
 
 
@@ -120,9 +131,8 @@ def create_app():
     if app:
         try:
             import maya.cmds
-            import gazupublisher.working_context as w
 
-            w.working_context = "MAYA"
+            set_working_context("MAYA")
         except:
             pass
     else:
@@ -164,7 +174,6 @@ def main():
 
 
 if __name__ == "__main__":
-    import gazupublisher.working_context as w
-    w.working_context = "STANDALONE"
-    print("Working context : " + w.working_context)
+    set_working_context("STANDALONE")
+    print("Working context : " + get_working_context())
     main()

--- a/gazupublisher/__main__.py
+++ b/gazupublisher/__main__.py
@@ -27,13 +27,22 @@ def excepthook(exc_type, exc_value, exc_traceback):
     """
     Handle unexpected errors by popping an error window and restarting the app.
     """
-    header = "\n=== An error occured !=== \nError message:\n"
-    traceback_print = "".join(
-        traceback.format_exception(exc_type, exc_value, exc_traceback)
+
+    string_tb = traceback.format_exception(exc_type, exc_value, exc_traceback)
+    from_gazupublisher = any(
+        "gazupublisher" in tb_step for tb_step in string_tb
     )
+    if not from_gazupublisher:
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    header = "\n=== An error occured !=== \nError message:\n"
+    traceback_print = "".join(string_tb)
+
     message = "%s%s" % (header, traceback_print)
     if is_blender_context():
         from gazupublisher.utils.blender import blender_print
+
         blender_print(message)
     else:
         print(message)

--- a/gazupublisher/resources/views/TakePreviewWidget.ui
+++ b/gazupublisher/resources/views/TakePreviewWidget.ui
@@ -273,7 +273,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="preview_label">
+          <widget class="QLabel" name="preview_widget">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>

--- a/gazupublisher/resources/views/TakePreviewWidget.ui
+++ b/gazupublisher/resources/views/TakePreviewWidget.ui
@@ -292,6 +292,9 @@
            <property name="text">
             <string/>
            </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
           </widget>
          </item>
         </layout>

--- a/gazupublisher/software_link/blender/launch_kitsu.py
+++ b/gazupublisher/software_link/blender/launch_kitsu.py
@@ -80,7 +80,7 @@ class BlenderQtAppTimedQueue(bpy.types.Operator):
         except:
             return {"CANCELLED"}
 
-        import gazupublisher.working_context as w
+        from gazupublisher.working_context import set_working_context
         from gazupublisher.utils.connection import configure_host
         from gazupublisher.__main__ import create_app, create_login_window
         
@@ -88,7 +88,7 @@ class BlenderQtAppTimedQueue(bpy.types.Operator):
 
         if kitsu_host:
             configure_host(kitsu_host)
-        w.working_context = "BLENDER"
+        set_working_context("BLENDER")
         
         self._app = create_app()
         create_login_window(self._app)

--- a/gazupublisher/utils/blender.py
+++ b/gazupublisher/utils/blender.py
@@ -29,6 +29,7 @@ def setup_preview(output_path, extension):
     bpy.context.scene.render.image_settings.file_format = extension
     bpy.context.scene.render.filepath = output_path
 
+
 def setup_preview_animation(output_path, extension, container):
     """
     Setup preview context for animations.

--- a/gazupublisher/utils/software.py
+++ b/gazupublisher/utils/software.py
@@ -102,7 +102,6 @@ def list_cameras():
 
 
 def get_current_color_space():
-
     if is_blender_context():
         from gazupublisher.utils.blender import get_current_color_space
 
@@ -110,8 +109,12 @@ def get_current_color_space():
 
 
 def set_camera(camera):
-
     if is_blender_context():
         from gazupublisher.utils.blender import set_camera
 
         set_camera(camera)
+
+def software_print(data):
+    if is_blender_context():
+        from gazupublisher.utils.blender import blender_print
+        blender_print(data)

--- a/gazupublisher/utils/software.py
+++ b/gazupublisher/utils/software.py
@@ -3,22 +3,28 @@ Module that act as an interface. Its purpose is to uniform the results coming
 from different contexts.
 """
 
+from gazupublisher.working_context import (
+    is_blender_context,
+    is_maya_context,
+    is_standalone_context,
+)
+
 
 def take_render_screenshot(output_path, extension, use_viewtransform=True):
     """
     Take a rendered screenshot
     """
-    from gazupublisher.working_context import working_context
 
-    if working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import (
             take_render_screenshot,
             set_current_color_space,
         )
+
         if not use_viewtransform:
             set_current_color_space("Raw")
         take_render_screenshot(output_path, extension)
-    elif working_context == "MAYA":
+    elif is_maya_context():
         from gazupublisher.utils.maya import take_screenshot
 
         take_screenshot(output_path, extension)
@@ -28,32 +34,31 @@ def take_viewport_screenshot(output_path, extension):
     """
     Take a viewport screenshot
     """
-    from gazupublisher.working_context import working_context
 
-    if working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import take_viewport_screenshot
 
         take_viewport_screenshot(output_path, extension)
-    elif working_context == "MAYA":
+    elif is_maya_context():
         from gazupublisher.utils.maya import take_screenshot
 
         take_screenshot(output_path, extension)
+
 
 def take_render_animation(output_path, container, use_viewtransform=True):
     """
     Take a rendered animation
     """
-    from gazupublisher.working_context import working_context
-
-    if working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import (
             take_render_animation,
             set_current_color_space,
         )
+
         if not use_viewtransform:
             set_current_color_space("Raw")
         take_render_animation(output_path, container)
-    elif working_context == "MAYA":
+    elif is_maya_context():
         from gazupublisher.utils.maya import take_screenshot
 
         take_screenshot(output_path, container)
@@ -63,35 +68,33 @@ def take_viewport_animation(output_path, container):
     """
     Take a viewport animation
     """
-    from gazupublisher.working_context import working_context
 
-    if working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import take_viewport_animation
 
         take_viewport_animation(output_path, container)
-    elif working_context == "MAYA":
+    elif is_maya_context():
         from gazupublisher.utils.maya import take_screenshot
 
         take_screenshot(output_path, container)
+
 
 def list_cameras():
     """
     Return a list of tuple representing the cameras.
     Each tuple contains a camera object and its name.
     """
-    import gazupublisher.working_context as w
-
-    if w.working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import list_cameras
 
         return list_cameras()
 
-    elif w.working_context == "MAYA":
+    elif is_maya_context():
         from gazupublisher.utils.maya import list_cameras
 
         return list_cameras()
 
-    elif w.working_context == "STANDALONE":
+    elif is_standalone_context():
         return [
             ("CameraStandAlone1", "CameraObject1"),
             ("CameraStandAlone2", "CameraObject2"),
@@ -99,18 +102,16 @@ def list_cameras():
 
 
 def get_current_color_space():
-    import gazupublisher.working_context as w
 
-    if w.working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import get_current_color_space
 
         return get_current_color_space()
 
 
 def set_camera(camera):
-    import gazupublisher.working_context as w
 
-    if w.working_context == "BLENDER":
+    if is_blender_context():
         from gazupublisher.utils.blender import set_camera
 
         set_camera(camera)

--- a/gazupublisher/views/task_panel/CommentWidget.py
+++ b/gazupublisher/views/task_panel/CommentWidget.py
@@ -189,6 +189,11 @@ class CommentWidget(QtWidgets.QWidget):
         self.post_comment_header.setAutoFillBackground(True)
         self.post_comment_header.update()
 
+    def reload(self):
+        self.empty_text_edit()
+        self.reset_selector_btn()
+        self.set_task(self.task)
+
     def empty_text_edit(self):
         self.comment_text_edit.clear()
 

--- a/gazupublisher/views/task_panel/NoPreviewWidget.py
+++ b/gazupublisher/views/task_panel/NoPreviewWidget.py
@@ -1,10 +1,7 @@
-import webbrowser
-
 import Qt.QtWidgets as QtWidgets
 import Qt.QtGui as QtGui
 import Qt.QtCore as QtCore
 
-from gazupublisher.utils.connection import get_host
 from gazupublisher.ui_data.color import text_color
 
 
@@ -42,7 +39,7 @@ class NoPreviewWidget(QtWidgets.QWidget):
 
     def setup_link(self):
         self.no_preview_label.setText("<p> " + self.message + "</p>" +
-                                      "<a href=\"" + self.preview_url +" \">Click Here</a>")
+                                      "<a href={}>Click Here</a>".format(self.preview_url))
         self.no_preview_label.setTextFormat(QtCore.Qt.RichText)
         self.no_preview_label.setOpenExternalLinks(True)
         self.no_preview_label.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)

--- a/gazupublisher/views/task_panel/PreviewVideoWidget.py
+++ b/gazupublisher/views/task_panel/PreviewVideoWidget.py
@@ -1,14 +1,17 @@
 import os
 import importlib
 
-from Qt import QtCore, QtGui, QtWidgets, __binding__
-QtMultimedia = importlib.import_module(__binding__ + ".QtMultimedia")
-QtMultimediaWidgets = importlib.import_module(__binding__ + ".QtMultimediaWidgets")
+from Qt import QtCore, QtGui, QtWidgets
+
+from gazupublisher.working_context import get_current_binding
+
+QtMultimedia = importlib.import_module(get_current_binding() + ".QtMultimedia")
+QtMultimediaWidgets = importlib.import_module(
+    get_current_binding() + ".QtMultimediaWidgets"
+)
 
 from gazupublisher.utils.connection import get_file_data_from_url
-from gazupublisher.views.task_panel.PreviewWidget import (
-    PreviewWidget,
-)
+from gazupublisher.views.task_panel.PreviewWidget import PreviewWidget
 from gazupublisher.exceptions import MediaNotSetUp
 
 
@@ -111,9 +114,7 @@ class PreviewVideoWidget(PreviewWidget):
         self.media_player.mediaStatusChanged.connect(self.status_changed)
         self.media_player.error.connect(self.handle_error)
         self.media_player.setVolume(50)
-        self.media_player.setMedia(
-            QtMultimedia.QMediaContent(), self.buffer
-        )
+        self.media_player.setMedia(QtMultimedia.QMediaContent(), self.buffer)
         self.play_button.setEnabled(True)
 
 

--- a/gazupublisher/views/task_panel/TakePreviewWindow.py
+++ b/gazupublisher/views/task_panel/TakePreviewWindow.py
@@ -286,3 +286,8 @@ class TakePreviewWindow(QtWidgets.QDialog):
 
     def set_output_path(self, path):
         self.output_path = path
+
+    def resizeEvent(self, event):
+        if not self.is_video:
+            self.display_image_preview(self.output_path)
+        return super(QtWidgets.QDialog, self).resizeEvent(event)

--- a/gazupublisher/views/task_panel/TakePreviewWindow.py
+++ b/gazupublisher/views/task_panel/TakePreviewWindow.py
@@ -5,7 +5,11 @@ import Qt.QtWidgets as QtWidgets
 import Qt.QtGui as QtGui
 import Qt.QtCore as QtCore
 
-from gazupublisher.working_context import get_current_binding
+from gazupublisher.working_context import (
+    get_current_binding,
+    is_blender_context,
+    is_maya_context,
+)
 
 QtMultimedia = importlib.import_module(get_current_binding() + ".QtMultimedia")
 QtMultimediaWidgets = importlib.import_module(
@@ -23,6 +27,8 @@ from gazupublisher.utils.software import (
     set_camera,
     get_current_color_space,
 )
+from gazupublisher.exceptions import MediaNotSetUp
+from gazupublisher.views.task_panel.NoPreviewWidget import NoPreviewWidget
 
 
 class TakePreviewWindow(QtWidgets.QDialog):
@@ -78,7 +84,7 @@ class TakePreviewWindow(QtWidgets.QDialog):
         self.output_dir_line_edit = self.findChild(
             QtWidgets.QLineEdit, "output_dir_line_edit"
         )
-        self.preview_label = self.findChild(QtWidgets.QLabel, "preview_label")
+        self.preview_widget = self.findChild(QtWidgets.QLabel, "preview_widget")
         self.filename_lineedit = self.findChild(
             QtWidgets.QLineEdit, "filename_lineedit"
         )
@@ -96,9 +102,6 @@ class TakePreviewWindow(QtWidgets.QDialog):
         )
         self.frame_preview_layout = self.findChild(
             QtWidgets.QLayout, "frame_preview_layout"
-        )
-        self.preview_label = self.findChild(
-            QtWidgets.QLabel, "preview_label"
         )
 
         self.form_widget = self.findChild(QtWidgets.QWidget, "form_widget")
@@ -237,7 +240,10 @@ class TakePreviewWindow(QtWidgets.QDialog):
                 return
             use_viewtransform = self.viewtransform_checkbox.isChecked()
             take_render_animation(output_path, container, use_viewtransform)
-        self.display_video_preview(output_path)
+        try:
+            self.display_video_preview(output_path)
+        except:
+            self.display_error_preview(output_path)
         self.set_output_path(output_path)
         self.update_confirm_btn()
 
@@ -247,37 +253,57 @@ class TakePreviewWindow(QtWidgets.QDialog):
         """
         pixmap = QtGui.QPixmap(image_path)
         pixmap = pixmap.scaled(
-            self.preview_label.size(), QtCore.Qt.KeepAspectRatio
+            self.preview_widget.size(), QtCore.Qt.KeepAspectRatio
         )
-        self.preview_label.setPixmap(pixmap)
+        self.preview_widget.setPixmap(pixmap)
 
     def display_video_preview(self, animation_path):
         """
         Display the video.
         """
-        self.player = QtMultimedia.QMediaPlayer(self)
+        if is_blender_context() or is_maya_context():
+            raise MediaNotSetUp()
 
-        self.playlist = QtMultimedia.QMediaPlaylist(self.player)
-        self.content = QtMultimedia.QMediaContent(self.playlist, contentUrl=QtCore.QUrl(animation_path))
-        self.playlist.addMedia(self.content)
+        self.clear_preview()
 
-        self.videoWidget = QtMultimediaWidgets.QVideoWidget()
-        self.player.setVideoOutput(self.videoWidget)
-
-        self.preview_label.deleteLater()
-        self.frame_preview_layout.addWidget(self.videoWidget)
-
+        self.preview_widget = QtMultimediaWidgets.QVideoWidget()
+        self.preview_widget.resize(300, 300)
+        self.preview_widget.move(0, 0)
+        self.player = QtMultimedia.QMediaPlayer()
+        self.player.setVideoOutput(self.preview_widget)
+        self.player.setMedia(
+            QtMultimedia.QMediaContent(
+                QtCore.QUrl.fromLocalFile(animation_path)
+            )
+        )
+        self.frame_preview_layout.addWidget(self.preview_widget)
         self.player.play()
+
+    def display_error_preview(self, animation_path):
+        """
+        Display a replacement widget when previews couldn't be loaded.
+        """
+        self.clear_preview()
+        message = "Video lecture is not supported yet. <br/> " \
+                  "If you want to look at it, the video is available by clicking the link below <br/>" \
+                  "You can still upload the file by hitting 'Confirm'"
+        folder_path = "file://" + os.path.dirname(animation_path)
+        self.preview_widget = NoPreviewWidget(self, message, folder_path)
+        self.frame_preview_layout.addWidget(self.preview_widget)
 
     def accept_preview(self):
         """
         Close the window and gives back to the comment widget the path of the
-        capture
+        capture.
         """
         if self.output_path:
             self.comment_widget.post_path = self.output_path
             self.comment_widget.update_selector_btn()
             self.accept()
+
+    def clear_preview(self):
+        if self.preview_widget:
+            self.preview_widget.deleteLater()
 
     def show_error_label(self, text):
         self.error_label.setText(text)

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -106,7 +106,7 @@ class TaskPanel(QtWidgets.QWidget):
         Create the widgets.
         """
         self.update_header_labels()
-        self.update_post_comment_widget()
+        self.reload_post_comment_widget()
         self.create_preview()
         self.create_comments()
 
@@ -192,12 +192,11 @@ class TaskPanel(QtWidgets.QWidget):
         """
         self.list_comments = ListCommentTask(self, self.task)
 
-    def update_post_comment_widget(self):
+    def reload_post_comment_widget(self):
         """
-        Update the task associated to the post comment widget.
+        Reload the post comment widget.
         """
-        self.post_comment_widget.empty_text_edit()
-        self.post_comment_widget.set_task(self.task)
+        self.post_comment_widget.reload()
 
     def create_preview(self):
         """

--- a/gazupublisher/views/task_panel/TaskPanel.py
+++ b/gazupublisher/views/task_panel/TaskPanel.py
@@ -1,6 +1,4 @@
-import os
-
-from Qt import QtCore, QtGui, QtWidgets, QtCompat, __binding__
+from Qt import QtCore, QtGui, QtWidgets, QtCompat
 
 from gazupublisher.utils.data import get_all_previews_for_task
 from gazupublisher.utils.format import is_video
@@ -14,6 +12,11 @@ from gazupublisher.views.task_panel.ListCommentTask import ListCommentTask
 from gazupublisher.views.task_panel.CommentWidget import CommentWidget
 from gazupublisher.ui_data.color import main_color
 from gazupublisher.exceptions import MediaNotSetUp
+from gazupublisher.working_context import (
+    is_blender_context,
+    is_maya_context,
+    get_current_binding,
+)
 
 
 class TaskPanel(QtWidgets.QWidget):
@@ -155,7 +158,9 @@ class TaskPanel(QtWidgets.QWidget):
     def update_header_button(self):
         signal = self.header_task_open_webbrowser.clicked
         receivers_count = self.header_task_open_webbrowser.receivers(
-            str(signal) if __binding__.startswith("PySide") else signal
+            str(signal)
+            if get_current_binding().startswith("PySide")
+            else signal
         )
         if receivers_count > 0:
             self.header_task_open_webbrowser.clicked.disconnect()
@@ -203,10 +208,11 @@ class TaskPanel(QtWidgets.QWidget):
         else:
             try:
                 if is_video(self.preview_file):
-                    from gazupublisher.working_context import working_context
-
-                    if working_context in ["BLENDER", "MAYA"] or\
-                            __binding__ not in ["PySide2", "PyQt5"]:
+                    if (
+                        is_blender_context()
+                        or is_maya_context()
+                        or get_current_binding() not in ["PySide2", "PyQt5"]
+                    ):
                         # Video not supported yet on Blender nor Maya
                         # Qt video support introduced in PySide2/PyQt5
                         raise MediaNotSetUp()

--- a/gazupublisher/working_context.py
+++ b/gazupublisher/working_context.py
@@ -1,12 +1,18 @@
 from Qt import __binding__
 
-global working_context
 working_context = ""
 
 
 def get_current_binding():
     return __binding__
 
+
+def set_working_context(context):
+    global working_context
+    working_context = context
+
+def get_working_context():
+    return working_context
 
 def is_maya_context():
     return working_context == "MAYA"


### PR DESCRIPTION
**Problem**
The user needs to upload an animation generated directly by Blender from the app.

**Solution**
Animations can now be generated from Blender. However, they still can't be displayed.
The preview images can now be resized.
The working context module has been refactored to clean the code.
Fix a bug which made pop up the gazu publisher error window for unrelated errors made in the Blender Python console