### PR TITLE
Debug publisher

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ dccutils = "*"
 gstreamer-player = "*"
 "gazu" = "0.8.4"
 "pytz" = "*"
+"shiboken2" = "*"
 
 [dev-packages]
 "Pytest" = "*"

--- a/kitsupublisher/__main__.py
+++ b/kitsupublisher/__main__.py
@@ -153,10 +153,21 @@ def create_app():
     """
     If we are in a qt built-in context (Maya, Houdini, ...), an instance of app
     already exists.
+    It seems that Maya2020 can return a QCoreApplication object instead of a
+    QApplication one,
     """
     app = QtCore.QCoreApplication.instance()
     if not (is_qt_context()):
         app = QtWidgets.QApplication(sys.argv)
+    if type(app) == QtCore.QCoreApplication:
+        try:
+            import shiboken2
+            app = shiboken2.wrapInstance(
+                shiboken2.getCppPointer(QtWidgets.QApplication.instance())[0],
+                QtWidgets.QApplication
+            )
+        except ImportError:
+            pass
     setup_style(app)
     sys.excepthook = excepthook
     return app

--- a/kitsupublisher/__main__.py
+++ b/kitsupublisher/__main__.py
@@ -155,12 +155,7 @@ def create_app():
     already exists.
     """
     app = QtCore.QCoreApplication.instance()
-    if app:
-        if check_module_import("maya.cmds"):
-            set_working_context("MAYA")
-        elif check_module_import("hou"):
-            set_working_context("HOUDINI")
-    else:
+    if not (is_qt_context()):
         app = QtWidgets.QApplication(sys.argv)
     setup_style(app)
     sys.excepthook = excepthook

--- a/kitsupublisher/software_link/houdini/123.py
+++ b/kitsupublisher/software_link/houdini/123.py
@@ -50,9 +50,11 @@ def launch_kitsu():
     launch the interface.
     """
     try:
+        from kitsupublisher.working_context import set_working_context
+        set_working_context("HOUDINI")
+
         import kitsupublisher.__main__
         from kitsupublisher.utils.connection import configure_host
-
         kitsu_host = os.environ.get("CGWIRE_HOST", None)
         if kitsu_host:
             configure_host(kitsu_host)

--- a/kitsupublisher/software_link/maya/userSetup.py
+++ b/kitsupublisher/software_link/maya/userSetup.py
@@ -52,11 +52,14 @@ def launch_kitsu(*args):
     """
     Launch the publisher.
     """
+
     try:
         add_gazu_publisher_location_to_sys_path()
+        from kitsupublisher.working_context import set_working_context
+        set_working_context("MAYA")
+
         import kitsupublisher.__main__
         from kitsupublisher.utils.connection import configure_host
-
         if kitsu_host:
             configure_host(kitsu_host)
         kitsupublisher.__main__.main()

--- a/kitsupublisher/views/task_panel/PreviewImageWidget.py
+++ b/kitsupublisher/views/task_panel/PreviewImageWidget.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from Qt import QtWidgets, QtGui, QtCore
 
@@ -46,9 +47,9 @@ class PreviewImageWidget(PreviewWidget):
         PreviewWidget.__init__(self, parent, preview_file)
 
     def complete_ui(self):
-        self.preview_url = os.path.join(
+        self.preview_url = Path(
             "pictures",
-            "previews",
+            "originals",
             "preview-files",
             self.preview_file["id"] + "." + self.preview_file["extension"],
         )
@@ -64,7 +65,8 @@ class PreviewImageWidget(PreviewWidget):
         Load preview image into label widget.
         """
         try:
-            data = get_file_data_from_url(self.preview_url).content
+            url = str(self.preview_url)
+            data = get_file_data_from_url(url).content
             pixmap = QtGui.QPixmap()
             pixmap.loadFromData(data)
             pixmap = pixmap.scaled(

--- a/kitsupublisher/views/task_panel/PreviewVideoWidget.py
+++ b/kitsupublisher/views/task_panel/PreviewVideoWidget.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+from pathlib import Path
 
 from Qt import QtCore, QtGui, QtWidgets
 
@@ -92,13 +93,14 @@ class PreviewVideoWidget(PreviewWidget):
         self.setup_video_player()
 
     def setup_video_player(self):
-        self.preview_url = os.path.join(
+        self.preview_url = Path(
             "movies",
             "originals",
             "preview-files",
             self.preview_file["id"] + "." + self.preview_file["extension"],
         )
-        self.open_file(self.preview_url)
+        url = str(self.preview_url)
+        self.open_file(url)
 
         self.media_player = QtMultimedia.QMediaPlayer(
             None, QtMultimedia.QMediaPlayer.StreamPlayback

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ install_requirements = [
     "qtazu",
     "qt.py",
     "dccutils",
-    "pytz"
+    "pytz",
+    "shiboken2"
 ]
 
 setup(


### PR DESCRIPTION
**Problem**
Some users have faced problems regarding the launch of the app in Maya2020-Windows (cf https://github.com/cgwire/kitsu-publisher/issues/56). This PR does not garant the stable behaviour of the app on Windows though, since proper testing has not been done and the app may remain unstable

**Solution**
- The way the working context is detected has been changed. Instead of looking for modules belonging to each software (_hou_ for Houdini, _maya.cmds_ for Maya), the detection will now be made on the custom startup files given with the code of the main app.
- Some paths were updated so the behaviour would work both on Windows and Linux using the pathlib library. This will authorize the display of images that previously failed because the url build was depending on the OS.
- When querying the qt app, Maya 2020 can apparently return an instance of _QtCore.QCoreApplication_ instead of _QtWidgets.QApplication_. Unfortunately, I've not witnessed this behaviour on my fresh install of the publisher (Maya2020 - windows10). I still added a fix based on shiboken2 (as in https://github.com/MoonShineVFX/pyblish-qml/commit/19b96529860cef6efe5e0f2601407560135a6968), but have not been able to test it in real conditions. If the bug still persists, then there will need some additional work